### PR TITLE
Added max_limit option to config file

### DIFF
--- a/config/apihandler.php
+++ b/config/apihandler.php
@@ -16,6 +16,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Max Limit for query
+    |--------------------------------------------------------------------------
+    |
+    | Defines the max limit of resutls that can be obtained, if null is defined
+    | results are limited as that of "limit" query parameter
+    |
+     */
+
+    'max_limit' => null,
+    
+    /*
+    |--------------------------------------------------------------------------
     | Envelope
     |--------------------------------------------------------------------------
     |
@@ -62,7 +74,7 @@ return [
 
     'errors' => [
         'ResourceNotFound' => ['http_code' => 404, 'message' => 'The requested resource could not be found but may be available again in the future.'],
-        'InternalError' => 	['http_code' => 500, 'message' => 'Internal server error'],
+        'InternalError' =>  ['http_code' => 500, 'message' => 'Internal server error'],
         'Unauthorized' => ['http_code' => 401, 'message' => 'Authentication is required and has failed or has not yet been provided'],
         'Forbidden' => ['http_code' => 403, 'message' => 'You don\'t have enough permissions to access this resource'],
         'ToManyRequests' => ['http_code' => 429, 'message' => 'You have sent too many requests in a specific timespan'],

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -59,6 +59,13 @@ class Parser
     public $envelope;
 
     /**
+     * Maximum limit for response
+     *
+     * @var int
+     */
+    public $maxLimit;
+
+    /**
      * The base query builder instance.
      *
      * @var \Illuminate\Database\Query\Builder
@@ -132,6 +139,7 @@ class Parser
 
         $this->prefix = Config::get('apihandler.prefix');
         $this->envelope = Config::get('apihandler.envelope');
+        $this->maxLimit = Config::get('apihandler.max_limit');
 
         $isEloquentModel = is_subclass_of($builder, '\Illuminate\Database\Eloquent\Model');
         $isEloquentRelation = is_subclass_of($builder, '\Illuminate\Database\Eloquent\Relations\Relation');
@@ -186,7 +194,17 @@ class Parser
             //Parse and apply limit using the laravel "limit" function
             if ($limit = $this->getParam('limit')) {
                 $limit = intval($limit);
-                $this->query->limit($limit);
+
+                if($limit <= $this->maxLimit) {
+                    $this->query->limit($limit);
+                }
+                elseif($limit === null) {
+                    $this->query->limit($limit);
+                }
+                else {
+                    $limit = intval($this->maxLimit);
+                    $this->query->limit($limit);
+                }
             }
 
             //Parse and apply the filters using the different laravel "where" functions


### PR DESCRIPTION
Added max_limit option to config file. This is very helpful for limiting the results that can be fetched.

It is very helpful in preventing server abuse by requesting large number for results such as `?q=99999`

If null is defined then the number `max_limit` option is ineffective and number of results will be equivalent as that of number passed in `limit` parameter.