### PR TITLE
Update to laravel 5.4

### DIFF
--- a/src/ApiHandlerServiceProvider.php
+++ b/src/ApiHandlerServiceProvider.php
@@ -30,7 +30,7 @@ class ApiHandlerServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app['ApiHandler'] = $this->app->share(function ($app) {
+        $this->app['ApiHandler'] = $this->app->singleton('Marcelgwerder\ApiHandler', function ($app) {
             return new ApiHandler;
         });
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -375,12 +375,22 @@ class Parser
                     $secondKey = $relation->getQualifiedParentKeyName();
                 } else if ($relationType === 'HasMany' || $relationType === 'HasOne') {
                     $firstKey = $relation->getQualifiedParentKeyName();
-                    $secondKey = $relation->getForeignKey();
+                    if (method_exists($relation, 'getQualifiedForeignKeyName')) {
+                        $secondKey = $relation->getQualifiedForeignKeyName();
+                    } else {
+                        // compatibility for laravel < 5.4
+                        $secondKey = $relation->getForeignKey();
+                    }
                 } else if ($relationType === 'BelongsToMany') {
                     $firstKey = $relation->getQualifiedParentKeyName();
                     $secondKey = $relation->getRelated()->getQualifiedKeyName();
                 } else if ($relationType === 'HasManyThrough') {
-                    $firstKey = $relation->getHasCompareKey();
+                    if (method_exists($relation, 'getExistenceCompareKey')) {
+                        $firstKey = $relation->getExistenceCompareKey();
+                    } else {
+                        // compatibility for laravel < 5.4
+                        $firstKey = $relation->getHasCompareKey();
+                    }
                     $secondKey = null;
                 } else {
                     die('Relation type not supported!');


### PR DESCRIPTION
The legacy method Application::share has been removed in laravel 5.4 and should be replaced with Application::singleton.