### PR TITLE
Remove orders from count query

### DIFF
--- a/src/CountMetaProvider.php
+++ b/src/CountMetaProvider.php
@@ -16,6 +16,9 @@ class CountMetaProvider extends MetaProvider
 
         //Remove offset from builder because a count doesn't work in combination with an offset
         $this->builder->offset = null;
+
+        //Remove orders from builder because they are irrelevant for counts and can cause errors with renamed columns
+        $this->builder->orders = null;
     }
 
     /**


### PR DESCRIPTION
If you have a custom column name (`SELECT id AS test`) and want to sort by this column with the `_config=meta-filter-count` param present, the count query fails with `Column not found: test`.
The orders can be removed from the count query because they are not relevant as the number of results will be the same.