### PR TITLE
Correct meta counts for builders with groups

### DIFF
--- a/src/CountMetaProvider.php
+++ b/src/CountMetaProvider.php
@@ -1,6 +1,6 @@
 <?php namespace Marcelgwerder\ApiHandler;
 
-use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
 
 class CountMetaProvider extends MetaProvider
 {
@@ -37,7 +37,7 @@ class CountMetaProvider extends MetaProvider
             $this->builder->limit = null;
 
             //Use the original builder as a subquery and count over it because counts over groups return the number of rows for each group, not for the total results
-            $query = resolve(Builder::class)->selectRaw('count(*) as aggregate from (' . $this->builder->toSql() . ') as count_table', $this->builder->getBindings());
+            $query = DB::query()->selectRaw('count(*) as aggregate from (' . $this->builder->toSql() . ') as count_table', $this->builder->getBindings());
             return intval($query->first()->aggregate);
         }
 

--- a/src/CountMetaProvider.php
+++ b/src/CountMetaProvider.php
@@ -1,5 +1,7 @@
 <?php namespace Marcelgwerder\ApiHandler;
 
+use Illuminate\Database\Query\Builder;
+
 class CountMetaProvider extends MetaProvider
 {
     /**
@@ -28,6 +30,17 @@ class CountMetaProvider extends MetaProvider
      */
     public function get()
     {
+        if (!empty($this->builder->groups)) {
+            //Only a count column is required
+            $this->builder->columns = [];
+            $this->builder->selectRaw('count(*) as aggregate');
+            $this->builder->limit = null;
+
+            //Use the original builder as a subquery and count over it because counts over groups return the number of rows for each group, not for the total results
+            $query = resolve(Builder::class)->selectRaw('count(*) as aggregate from (' . $this->builder->toSql() . ') as count_table', $this->builder->getBindings());
+            return intval($query->first()->aggregate);
+        }
+
         return intval($this->builder->count());
     }
 }


### PR DESCRIPTION
When using meta-total-count or meta-filter-count with a builder containing a groupBy statement, the counts are inaccurate as the laravel count() method does not count the total results but the results for each group and returns only the first group.