### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ This helper package provides functionality for parsing the URL of a REST-API req
 
 ***Note:*** This version is for Laravel 5. When using Laravel 4 you need to use version 0.4.x.
 
-Install the package through composer by running `composer require marcelgwerder/laravel-api-handler`
+Install the package through composer by running 
+```
+composer require marcelgwerder/laravel-api-handler
+```
 
 Once composer finished add the service provider to the `providers` array in `app/config/app.php`:
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install the package through composer by adding it to your `composer.json` file:
     "marcelgwerder/laravel-api-handler": "dev-master"
 }
 ```
-or run `composer require marcelgwerder/laravel-api-handler`
+* or run `composer require marcelgwerder/laravel-api-handler`
 
 Then run `composer update`. Once composer finished add the service provider to the `providers` array in `app/config/app.php`:
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This helper package provides functionality for parsing the URL of a REST-API req
 
 Install the package through composer by running `composer require marcelgwerder/laravel-api-handler`
 
-Then run `composer update`. Once composer finished add the service provider to the `providers` array in `app/config/app.php`:
+Once composer finished add the service provider to the `providers` array in `app/config/app.php`:
 ```
 Marcelgwerder\ApiHandler\ApiHandlerServiceProvider::class,
 ```

--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Install the package through composer by adding it to your `composer.json` file:
     "marcelgwerder/laravel-api-handler": "dev-master"
 }
 ```
+or run `composer require marcelgwerder/laravel-api-handler`
+
 Then run `composer update`. Once composer finished add the service provider to the `providers` array in `app/config/app.php`:
 ```
-'Marcelgwerder\ApiHandler\ApiHandlerServiceProvider'
+Marcelgwerder\ApiHandler\ApiHandlerServiceProvider::class,
 ```
 Now import the `ApiHandler` facade into your classes:
 ```php
@@ -24,7 +26,7 @@ use Marcelgwerder\ApiHandler\Facades\ApiHandler;
 ```
 Or set an alias in `app.php`:
 ```
-'ApiHandler' => 'Marcelgwerder\ApiHandler\Facades\ApiHandler',
+'ApiHandler' => Marcelgwerder\ApiHandler\Facades\ApiHandler::class,
 ```
 That's it!
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,7 @@ This helper package provides functionality for parsing the URL of a REST-API req
 
 ***Note:*** This version is for Laravel 5. When using Laravel 4 you need to use version 0.4.x.
 
-Install the package through composer by adding it to your `composer.json` file:
-
-```
-"require": {
-    "marcelgwerder/laravel-api-handler": "dev-master"
-}
-```
-* or run `composer require marcelgwerder/laravel-api-handler`
+Install the package through composer by running `composer require marcelgwerder/laravel-api-handler`
 
 Then run `composer update`. Once composer finished add the service provider to the `providers` array in `app/config/app.php`:
 ```


### PR DESCRIPTION
Update readme to have direct pull of package instruction from CLI and update call examples for `app.php`  to reflect current Laravel name conventions. 