### PR TITLE
Add toString to result

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -283,4 +283,14 @@ class Result
 
         return $response;
     }
+
+    /**
+     * Convert the result to its string representation.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getResponse()->__toString();
+    }
 }


### PR DESCRIPTION
This will allow us to use:

```php
return ApiHandler::parseMultiple($book, array('title', 'isbn', 'description'));
```

Instead of the current
```php
return ApiHandler::parseMultiple($book, array('title', 'isbn', 'description'))->getResponse();
```