### PR TITLE
PHP 7.2 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 ## Laravel API Handler
-[![Build Status](https://travis-ci.org/marcelgwerder/laravel-api-handler.png?branch=master)](https://travis-ci.org/marcelgwerder/laravel-api-handler) [![Latest Stable Version](https://poser.pugx.org/marcelgwerder/laravel-api-handler/v/stable.png)](https://packagist.org/packages/marcelgwerder/laravel-api-handler) [![Total Downloads](https://poser.pugx.org/marcelgwerder/laravel-api-handler/downloads.png)](https://packagist.org/packages/marcelgwerder/laravel-api-handler) [![License](https://poser.pugx.org/marcelgwerder/laravel-api-handler/license.png)](https://packagist.org/packages/marcelgwerder/laravel-api-handler)
 
 This helper package provides functionality for parsing the URL of a REST-API request.
+
+### Attention
+
+This is a fix for `marcelgwerder/laravel-api-handler` on PHP 7.2. There is a pull request in original package.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 ## Laravel API Handler
+[![Build Status](https://travis-ci.org/marcelgwerder/laravel-api-handler.png?branch=master)](https://travis-ci.org/marcelgwerder/laravel-api-handler) [![Latest Stable Version](https://poser.pugx.org/marcelgwerder/laravel-api-handler/v/stable.png)](https://packagist.org/packages/marcelgwerder/laravel-api-handler) [![Total Downloads](https://poser.pugx.org/marcelgwerder/laravel-api-handler/downloads.png)](https://packagist.org/packages/marcelgwerder/laravel-api-handler) [![License](https://poser.pugx.org/marcelgwerder/laravel-api-handler/license.png)](https://packagist.org/packages/marcelgwerder/laravel-api-handler)
 
 This helper package provides functionality for parsing the URL of a REST-API request.
-
-### Attention
-
-This is a fix for `marcelgwerder/laravel-api-handler` on PHP 7.2. There is a pull request in original package.
 
 ### Installation
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
-    "name": "betalabs/laravel-api-handler",
-    "description": "Package providing helper functions for a Laravel REST-API. This is a fix for PHP 7.2.",
+    "name": "marcelgwerder/laravel-api-handler",
+    "description": "Package providing helper functions for a Laravel REST-API ",
     "keywords": ["api", "laravel", "rest", "url", "parse", "mysql"],
+    "homepage": "http://github.com/marcelgwerder/laravel-api-handler",
     "license": "MIT",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,7 @@
 {
-    "name": "marcelgwerder/laravel-api-handler",
-    "description": "Package providing helper functions for a Laravel REST-API ",
+    "name": "betalabs/laravel-api-handler",
+    "description": "Package providing helper functions for a Laravel REST-API. This is a fix for PHP 7.2.",
     "keywords": ["api", "laravel", "rest", "url", "parse", "mysql"],
-    "homepage": "http://github.com/marcelgwerder/laravel-api-handler",
     "license": "MIT",
     "authors": [
         {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -328,7 +328,7 @@ class Parser
     protected function parseWith($withParam)
     {
         $fields = $this->query->columns;
-        $fieldsCount = count($fields);
+        $fieldsCount = count($fields ?: []);
         $baseModel = $this->builder->getModel();
 
         $withHistory = [];
@@ -449,7 +449,7 @@ class Parser
         $this->builder->with($withsArr);
 
         //Merge the base fields
-        if (count($fields) > 0) {
+        if (count($fields ?: []) > 0) {
             if (!is_array($this->query->columns)) {
                 $this->query->columns = [];
             }


### PR DESCRIPTION
Now PHP 7.2 checks for type when using `count()`, sometimes `$this->query->columns` return `null`. Before `count()` returned `0` in this case now it throws an exception; this simple fix checks for `null` and return an empty array instead.