### PR TITLE
HasManyThrough relation fix

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -391,7 +391,10 @@ class Parser
                     $firstKey = $relation->getQualifiedParentKeyName();
                     $secondKey = $relation->getRelated()->getQualifiedKeyName();
                 } else if ($relationType === 'HasManyThrough') {
-                    if (method_exists($relation, 'getExistenceCompareKey')) {
+                    if (method_exists($relation, 'getQualifiedLocalKeyName')) {
+                        $firstKey = $relation->getQualifiedLocalKeyName();
+                    } elseif (method_exists($relation, 'getExistenceCompareKey')) {
+                        // compatibility for laravel 5.4
                         $firstKey = $relation->getExistenceCompareKey();
                     } else {
                         // compatibility for laravel < 5.4

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -393,7 +393,7 @@ class Parser
                 } else if ($relationType === 'HasManyThrough') {
                     if (method_exists($relation, 'getQualifiedLocalKeyName')) {
                         $firstKey = $relation->getQualifiedLocalKeyName();
-                    } elseif (method_exists($relation, 'getExistenceCompareKey')) {
+                    } else if (method_exists($relation, 'getExistenceCompareKey')) {
                         // compatibility for laravel 5.4
                         $firstKey = $relation->getExistenceCompareKey();
                     } else {


### PR DESCRIPTION
Method `getExistenceCompareKey()` for HasManyThrough relation is not present in Laravel 5.5, this method was renamed to `getQualifiedLocalKeyName()` as you can see here: https://github.com/laravel/framework/pull/22071.

If we try to use `_with` in a `HasManyThrough` relation method it returns an exception:
```
BadMethodCallException : Call to undefined method Illuminate\Database\Query\Builder::getHasCompareKey()
 /home/vagrant/Code/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:2461
 /home/vagrant/Code/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:1273
 /home/vagrant/Code/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Relations/Relation.php:367
 /home/vagrant/Code/vendor/marcelgwerder/laravel-api-handler/src/Parser.php:403
 /home/vagrant/Code/vendor/marcelgwerder/laravel-api-handler/src/Parser.php:234
```

However with the proposed change it returns the relation as expected.