### PR TITLE
Update Parser.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~8.0",
-        "illuminate/database": "~8.0",
-        "illuminate/http": "~8.0"
+        "illuminate/support": "~8.0|~9.0|~10.0",
+        "illuminate/database": "~8.0|~9.0|~10.0",
+        "illuminate/http": "~8.0|~9.0|~10.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.8|^9.3.3",

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~7.0",
-        "illuminate/database": "~7.0",
-        "illuminate/http": "~7.0"
+        "illuminate/support": "~8.0",
+        "illuminate/database": "~8.0",
+        "illuminate/http": "~8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.8|^9.3.3",

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~6.0",
-        "illuminate/database": "~6.0",
-        "illuminate/http": "~6.0"
+        "illuminate/support": "~7.0",
+        "illuminate/database": "~7.0",
+        "illuminate/http": "~7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5",
-        "mockery/mockery": "~0.9"
+        "phpunit/phpunit": "^8.5.8|^9.3.3",
+        "mockery/mockery": "~1.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5.0",
-        "illuminate/database": "~5.0",
-        "illuminate/http": "~5.0"
+        "illuminate/support": "~6.0",
+        "illuminate/database": "~6.0",
+        "illuminate/http": "~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",

--- a/src/ApiHandler.php
+++ b/src/ApiHandler.php
@@ -1,7 +1,7 @@
 <?php namespace Marcelgwerder\ApiHandler;
 
-use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Response;
+use Illuminate\Support\Facades\Request;
 
 class ApiHandler
 {
@@ -16,7 +16,7 @@ class ApiHandler
     public function parseSingle($queryBuilder, $identification, $queryParams = false)
     {
         if ($queryParams === false) {
-            $queryParams = Input::get();
+            $queryParams = Request::input();
         }
 
         $parser = new Parser($queryBuilder, $queryParams);
@@ -36,7 +36,7 @@ class ApiHandler
     public function parseMultiple($queryBuilder, $fullTextSearchColumns = array(), $queryParams = false)
     {
         if ($queryParams === false) {
-            $queryParams = Input::get();
+            $queryParams = Request::input();
         }
 
         $parser = new Parser($queryBuilder, $queryParams);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -280,9 +280,7 @@ class Parser
         $reserved = array_fill_keys($this->functions, true);
         $prefix = $this->prefix;
 
-        $filterParams = array_diff_ukey($this->params, $reserved, function ($a, $b) use ($prefix) {
-            return $a != $prefix.$b;
-        });
+        $filterParams = array_diff_ukey($this->params, $reserved, static fn ($a, $b): int => $a <=> $prefix.$b);
 
         if (count($filterParams) > 0) {
             return $filterParams;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -377,29 +377,16 @@ class Parser
                 $relationType = $this->getRelationType($relation);
 
                 if ($relationType === 'BelongsTo') {
-                    $firstKey = $relation->getQualifiedForeignKey();
+                    $firstKey = $relation->getQualifiedForeignKeyName();
                     $secondKey = $relation->getQualifiedParentKeyName();
                 } else if ($relationType === 'HasMany' || $relationType === 'HasOne') {
                     $firstKey = $relation->getQualifiedParentKeyName();
-                    if (method_exists($relation, 'getQualifiedForeignKeyName')) {
-                        $secondKey = $relation->getQualifiedForeignKeyName();
-                    } else {
-                        // compatibility for laravel < 5.4
-                        $secondKey = $relation->getForeignKey();
-                    }
+                    $secondKey = $relation->getQualifiedForeignKeyName();
                 } else if ($relationType === 'BelongsToMany') {
                     $firstKey = $relation->getQualifiedParentKeyName();
                     $secondKey = $relation->getRelated()->getQualifiedKeyName();
                 } else if ($relationType === 'HasManyThrough') {
-                    if (method_exists($relation, 'getQualifiedLocalKeyName')) {
-                        $firstKey = $relation->getQualifiedLocalKeyName();
-                    } else if (method_exists($relation, 'getExistenceCompareKey')) {
-                        // compatibility for laravel 5.4
-                        $firstKey = $relation->getExistenceCompareKey();
-                    } else {
-                        // compatibility for laravel < 5.4
-                        $firstKey = $relation->getHasCompareKey();
-                    }
+                    $firstKey = $relation->getQualifiedLocalKeyName();
                     $secondKey = null;
                 } else {
                     die('Relation type not supported!');


### PR DESCRIPTION
According to https://laravel.com/docs/5.8/upgrade#eloquent method's names must be changed.

This change is only for 5.8 and up without backward compatibility. I suggest separate version/branch.